### PR TITLE
feat: add basic wallet scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # LuckYouWallet
+
+Minimal Web3 wallet framework scaffold built with Node.js.
+
+## Features
+
+- Generate a new wallet using the `secp256k1` curve
+- Derive a simple address from the wallet's public key
+- Sign and verify arbitrary messages
+- Export and restore wallets from PEM encoded private keys
+
+> **Note:** This project avoids external dependencies. For full Ethereum
+> compatibility (e.g. true `keccak256` addresses, transaction signing and
+> mnemonic phrases) integrate a library such as `ethers`.
+
+## Development
+
+Run the test suite:
+
+```bash
+npm test
+```
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "luckyouwallet",
+  "version": "0.1.0",
+  "description": "Minimal Web3 wallet framework scaffold",
+  "main": "src/wallet.js",
+  "scripts": {
+    "test": "node test/wallet.test.js"
+  },
+  "keywords": ["web3", "wallet"],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -1,0 +1,48 @@
+const crypto = require('crypto');
+
+class Wallet {
+  constructor(privateKey, publicKey) {
+    this.privateKey = privateKey;
+    this.publicKey = publicKey;
+    this.address = Wallet.computeAddress(publicKey);
+  }
+
+  static generate() {
+    const { privateKey, publicKey } = crypto.generateKeyPairSync('ec', {
+      namedCurve: 'secp256k1'
+    });
+    return new Wallet(privateKey, publicKey);
+  }
+
+  static fromPrivateKey(pem) {
+    const privateKey = crypto.createPrivateKey({ key: pem, format: 'pem' });
+    const publicKey = crypto.createPublicKey(privateKey);
+    return new Wallet(privateKey, publicKey);
+  }
+
+  static computeAddress(publicKey) {
+    const pubDer = publicKey.export({ type: 'spki', format: 'der' });
+    const hash = crypto.createHash('sha256').update(pubDer).digest('hex');
+    return '0x' + hash.slice(-40); // last 20 bytes as address
+  }
+
+  exportPrivateKey() {
+    return this.privateKey.export({ type: 'pkcs8', format: 'pem' });
+  }
+
+  signMessage(message) {
+    const sign = crypto.createSign('sha256');
+    sign.update(message);
+    sign.end();
+    return sign.sign(this.privateKey, 'hex');
+  }
+
+  verifyMessage(message, signature) {
+    const verify = crypto.createVerify('sha256');
+    verify.update(message);
+    verify.end();
+    return verify.verify(this.publicKey, signature, 'hex');
+  }
+}
+
+module.exports = { Wallet };

--- a/test/wallet.test.js
+++ b/test/wallet.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const { Wallet } = require('../src/wallet');
+
+function testGenerate() {
+  const wallet = Wallet.generate();
+  assert.ok(/^0x[a-f0-9]{40}$/.test(wallet.address));
+  const message = 'hello';
+  const sig = wallet.signMessage(message);
+  assert.ok(wallet.verifyMessage(message, sig));
+}
+
+function testExportRestore() {
+  const wallet1 = Wallet.generate();
+  const pem = wallet1.exportPrivateKey();
+  const wallet2 = Wallet.fromPrivateKey(pem);
+  assert.equal(wallet1.address, wallet2.address);
+}
+
+testGenerate();
+testExportRestore();
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- scaffold minimal Node.js wallet framework using `secp256k1`
- provide signing, verification, and key export/restore utilities
- document features and usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891d3a41ff8832c9bf78cab10716fd0