### PR TITLE
feat: add Ethereum frontend page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -21,3 +21,23 @@ Run the test suite:
 npm test
 ```
 
+
+## Frontend demo
+
+A simple HTML page that connects to an Ethereum wallet is available at `src/index.html`.
+
+### Run the demo
+
+1. Install a browser wallet extension such as MetaMask.
+2. Start a static file server in the `src` folder (for example `npx http-server src`).
+3. Open `http://localhost:8080/index.html` in your browser.
+4. Click **Connect Wallet** and approve the request in MetaMask.
+5. Your address and balance will appear and you can send ETH to another address.
+
+### Test the code
+
+Run the existing Node.js tests:
+
+```bash
+npm test
+```

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -1,0 +1,34 @@
+let provider;
+
+async function connect() {
+  if (!window.ethereum) {
+    alert('MetaMask is required');
+    return;
+  }
+  provider = new ethers.providers.Web3Provider(window.ethereum);
+  await provider.send('eth_requestAccounts', []);
+  const signer = provider.getSigner();
+  const address = await signer.getAddress();
+  document.getElementById('account').textContent = 'Address: ' + address;
+  const balance = await provider.getBalance(address);
+  document.getElementById('balance').textContent = 'Balance: ' + ethers.utils.formatEther(balance) + ' ETH';
+  document.getElementById('transfer').style.display = 'block';
+}
+
+async function send() {
+  const to = document.getElementById('to').value;
+  const amount = document.getElementById('amount').value;
+  try {
+    const signer = provider.getSigner();
+    const tx = await signer.sendTransaction({
+      to,
+      value: ethers.utils.parseEther(amount)
+    });
+    document.getElementById('tx').textContent = 'Transaction hash: ' + tx.hash;
+  } catch (err) {
+    document.getElementById('tx').textContent = 'Error: ' + err.message;
+  }
+}
+
+document.getElementById('connect').addEventListener('click', connect);
+document.getElementById('send').addEventListener('click', send);

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>LuckYouWallet Demo</title>
+</head>
+<body>
+  <h1>LuckYouWallet Frontend</h1>
+  <button id="connect">Connect Wallet</button>
+  <div id="account"></div>
+  <div id="balance"></div>
+  <div id="transfer" style="display:none;">
+    <input id="to" placeholder="Recipient address" />
+    <input id="amount" placeholder="Amount in ETH" />
+    <button id="send">Send ETH</button>
+    <div id="tx"></div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.min.js"></script>
+  <script src="frontend.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add browser-based demo that connects to a wallet and sends ETH
- document how to run the frontend and tests
- ignore development artifacts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891d60292c8832cae5db7a5e1be2c67