### PR TITLE
Add React testing setup and sample component

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }]
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -4,10 +4,22 @@
   "description": "Minimal Web3 wallet framework scaffold",
   "main": "src/wallet.js",
   "scripts": {
-    "test": "node test/wallet.test.js"
+    "test": "jest"
   },
   "keywords": ["web3", "wallet"],
   "author": "",
   "license": "MIT",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.22.0",
+    "@babel/preset-react": "^7.22.5",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0"
+  }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>LuckYouWallet</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function App() {
+  return <div>Hello World</div>;
+}
+
+export default App;

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from './App';
+
+test('renders Hello World text', () => {
+  render(<App />);
+  expect(screen.getByText(/Hello World/i)).toBeInTheDocument();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/test/wallet.test.js
+++ b/test/wallet.test.js
@@ -1,21 +1,16 @@
-const assert = require('assert');
 const { Wallet } = require('../src/wallet');
 
-function testGenerate() {
+test('generate wallet and sign message', () => {
   const wallet = Wallet.generate();
-  assert.ok(/^0x[a-f0-9]{40}$/.test(wallet.address));
+  expect(/^0x[a-f0-9]{40}$/.test(wallet.address)).toBe(true);
   const message = 'hello';
   const sig = wallet.signMessage(message);
-  assert.ok(wallet.verifyMessage(message, sig));
-}
+  expect(wallet.verifyMessage(message, sig)).toBe(true);
+});
 
-function testExportRestore() {
+test('export and restore wallet', () => {
   const wallet1 = Wallet.generate();
   const pem = wallet1.exportPrivateKey();
   const wallet2 = Wallet.fromPrivateKey(pem);
-  assert.equal(wallet1.address, wallet2.address);
-}
-
-testGenerate();
-testExportRestore();
-console.log('All tests passed.');
+  expect(wallet1.address).toBe(wallet2.address);
+});


### PR DESCRIPTION
## Summary
- set up React entry point and sample App component
- configure Jest and React Testing Library for React and wallet tests
- add Babel configuration for JSX support

## Testing
- `npm install` *(fails: 403 Forbidden for @babel/preset-env)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891e37a37bc832c92343ab36de66f74