### PR TITLE
Use bip39 for mnemonic generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "type": "commonjs",
   "dependencies": {
+    "bip39": "^3.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -1,26 +1,5 @@
 const crypto = require('crypto');
-
-const ALPHABET = 'abcdefghijklmnop'; // 16 characters for 256 combinations
-
-function byteToWord(b) {
-  const first = ALPHABET[Math.floor(b / 16)];
-  const second = ALPHABET[b % 16];
-  return first + second;
-}
-
-function wordToByte(word) {
-  if (word.length !== 2) throw new Error('Invalid mnemonic word');
-  const first = ALPHABET.indexOf(word[0]);
-  const second = ALPHABET.indexOf(word[1]);
-  if (first === -1 || second === -1) throw new Error('Invalid mnemonic word');
-  return first * 16 + second;
-}
-
-function mnemonicToSeed(mnemonic) {
-  const words = mnemonic.trim().split(/\s+/);
-  const bytes = Buffer.from(words.map(wordToByte));
-  return crypto.createHash('sha256').update(bytes).digest();
-}
+const bip39 = require('bip39');
 
 function fromPrivateKeyBytes(bytes) {
   const ecdh = crypto.createECDH('secp256k1');
@@ -59,13 +38,11 @@ class Wallet {
   }
 
   static generateMnemonic() {
-    const bytes = crypto.randomBytes(12);
-    const words = Array.from(bytes).map(byteToWord);
-    return words.join(' ');
+    return bip39.generateMnemonic();
   }
 
   static fromMnemonic(mnemonic) {
-    const seed = mnemonicToSeed(mnemonic);
+    const seed = bip39.mnemonicToSeedSync(mnemonic);
     return fromPrivateKeyBytes(seed.subarray(0, 32));
   }
 


### PR DESCRIPTION
## Summary
- replace custom mnemonic logic with `bip39`
- derive wallet seed via `bip39.mnemonicToSeedSync`
- add `bip39` to dependencies

## Testing
- `npm test` *(fails: Cannot find module 'bip39' -- registry returned 403 during install)*

------
https://chatgpt.com/codex/tasks/task_e_6892fc9a61f0832c97ae77777d740d93