### PR TITLE
feat: add eth send functionality

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,8 @@ export default function App() {
   const [address, setAddress] = useState('')
   const [privateKey, setPrivateKey] = useState('')
   const [balance, setBalance] = useState('')
+  const [gas, setGas] = useState('')
+  const [sendTime, setSendTime] = useState('')
 
   const queryBalance = async (addr) => {
     if (!addr) return
@@ -48,16 +50,42 @@ export default function App() {
     }
   }
 
+  const sendETH = async () => {
+    if (!privateKey) {
+      window.alert('请先导入或创建钱包')
+      return
+    }
+    const to = window.prompt('请输入收款地址') || ''
+    const amount = window.prompt('请输入发送金额(ETH)') || ''
+    if (!to || !amount) return
+    try {
+      const wallet = new ethers.Wallet(privateKey, provider)
+      const value = ethers.parseEther(amount)
+      const gasLimit = await wallet.estimateGas({ to, value })
+      setGas(gasLimit.toString())
+      const tx = await wallet.sendTransaction({ to, value, gasLimit })
+      const receipt = await tx.wait()
+      const block = await provider.getBlock(receipt.blockNumber)
+      setSendTime(new Date(block.timestamp * 1000).toLocaleString())
+      await queryBalance(wallet.address)
+    } catch (err) {
+      window.alert('发送失败：' + err.message)
+    }
+  }
+
   return (
     <div>
       <h1>钱包管理</h1>
       <button onClick={createWallet}>创建钱包</button>
       <button onClick={importWallet}>导入钱包</button>
       <button onClick={() => queryBalance(address)}>查询余额</button>
+      <button onClick={sendETH}>发送ETH</button>
       <p>{mnemonic}</p>
       <p>ETH地址：{address}</p>
       <p>ETH余额：{balance}</p>
       <p>私钥：{privateKey}</p>
+      <p>所需Gas：{gas}</p>
+      <p>发送时间：{sendTime}</p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- allow sending ETH from wallet
- show estimated gas and timestamp of sent transaction

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689464055670832cbb41ff1531f95e0d